### PR TITLE
Fix a few bugs found by gcc 7.1

### DIFF
--- a/CONFIGVARS
+++ b/CONFIGVARS
@@ -59,7 +59,7 @@ TAR   = tar
 #
 # optimizations
 # 
-OPTS = -O2 -fomit-frame-pointer
+OPTS = -O2 -fomit-frame-pointer -fno-strict-aliasing
 
 
 #

--- a/cflib/ascii_table.c
+++ b/cflib/ascii_table.c
@@ -49,7 +49,7 @@ _redraw_obj (OBJECT * tree, short obj)
 static void
 set_numbers (short code)
 {
-	char str[6];
+	char str[16];
 
 	sprintf (str, "%03d", code);
 	set_string (cf_ascii_tab, AT_DEZ, str);

--- a/cflib/filesel.c
+++ b/cflib/filesel.c
@@ -116,7 +116,7 @@ do_magx (char *path, char *name, char *mask, char *title, FSEL_CB open_cb)
 		}
 		pat[j++] = '\0';
 	}
-	for (i = 0; i < 5; i++)
+	for (i = 0; i < 3; i++)
 		pat[j++] = def_mask[i];
 
 	if (path[0] != '\0')

--- a/cflib/objc_get_string.c
+++ b/cflib/objc_get_string.c
@@ -60,7 +60,7 @@ get_string (OBJECT *tree, short obj, char *text)
 
 		default:
 		{
-			char s[30];
+			char s[96];
 
 			sprintf (s,
 				 "[3][CF-Lib Panic: get_string()!|Objekt %d hat unbekannten Typ %d|!][Abbruch]",

--- a/cflib/objc_set_string.c
+++ b/cflib/objc_set_string.c
@@ -60,7 +60,7 @@ set_string (OBJECT *tree, short obj, char *text)
 
 		default:
 		{
-			char s[30];
+			char s[96];
 
 			sprintf (s,
 				 "[3][CF-Lib Panic: set_string()!|Objekt %d hat unbekannten Typ %d|!][Abbruch]",


### PR DESCRIPTION
There has been a lot of strict aliasing complains so I think it makes sense to enable `-fno-strict-aliasing` until the wild pointer casts are fixed (there's a lot of them...) to prevent undefined behaviour.