### PR TITLE
v_opnvwk() binding should not set a default text size. 

### DIFF
--- a/v_opnvwk.c
+++ b/v_opnvwk.c
@@ -41,11 +41,6 @@ v_opnvwk (short work_in[], short *handle, short work_out[])
 		vsl_width(vdi_control[6],1);
 		vst_effects(vdi_control[6],0);
 		vsm_height(vdi_control[6],9);
-#if CHECK_NULLPTR
-		vst_height(vdi_control[6],13,0L,0L,0L,0L);
-#else
-		vst_height(vdi_control[6],13,&dummy,&dummy,&dummy,&dummy);
-#endif
 	}
 }
 


### PR DESCRIPTION
In particular, the chosen size of 13 caused ugly scaled fonts under ST low and medium resolution. Proposed fix for https://github.com/freemint/gemlib/issues/11